### PR TITLE
Add plain-text output as default, make JSON optional with --json flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,26 @@ A WordPress rest-enumeration script
 `pip install -r requirements.txt`
 
 # Usage
-Enumerate users and media files: `python ./wordpress-rest-enum.py -w https://targetwebsite.com -u -m `
+Enumerate users and media files (plain-text output): `python ./wordpress-rest-enum.py -w https://targetwebsite.com -u -m`
+
+Enumerate users and media files (JSON output): `python ./wordpress-rest-enum.py -w https://targetwebsite.com -u -m --json`
+
+## Output Formats
+
+### Plain Text (default)
+```
+===== https://targetwebsite.com =====
+
+[Users]
+  Name: John Doe
+  Username: johndoe
+  ---
+
+[Media]
+  https://targetwebsite.com/wp-content/uploads/2024/01/doc.pdf
+```
+
+### JSON (`--json` / `-j`)
+```json
+{"website": "https://targetwebsite.com", "users": [{"name": "John Doe", "username": "johndoe"}], "media": ["https://targetwebsite.com/wp-content/uploads/2024/01/doc.pdf"]}
+```

--- a/wordpress-rest-enum.py
+++ b/wordpress-rest-enum.py
@@ -91,6 +91,14 @@ parser.add_argument(
     required=False,
 )
 
+parser.add_argument(
+    "-j",
+    "--json",
+    help="Output results in JSON format (default is plain text)",
+    action="store_true",
+    required=False,
+)
+
 cliArgs = parser.parse_args()
 
 # Logging
@@ -216,6 +224,57 @@ def requestRESTAPI(
     return results
 
 
+def format_result_plain(result: dict) -> str:
+    """Format result dictionary as human-readable plain text."""
+    lines = []
+    lines.append(f"===== {result['website']} =====")
+
+    if "users" in result and result["users"]:
+        lines.append("")
+        lines.append("[Users]")
+        for user in result["users"]:
+            lines.append(f"  Name: {user['name']}")
+            lines.append(f"  Username: {user['username']}")
+            lines.append("  ---")
+
+    if "posts" in result and result["posts"]:
+        lines.append("")
+        lines.append("[Posts]")
+        for post in result["posts"]:
+            lines.append(f"  {post}")
+
+    if "pages" in result and result["pages"]:
+        lines.append("")
+        lines.append("[Pages]")
+        for page in result["pages"]:
+            lines.append(f"  {page}")
+
+    if "media" in result and result["media"]:
+        lines.append("")
+        lines.append("[Media]")
+        for media in result["media"]:
+            lines.append(f"  {media}")
+
+    if "comments" in result and result["comments"]:
+        lines.append("")
+        lines.append("[Comments]")
+        for comment in result["comments"]:
+            lines.append(f"  Name: {comment['name']}")
+            lines.append(f"  Date: {comment['date']}")
+            lines.append(f"  Link: {comment['link']}")
+            lines.append("  ---")
+
+    return "\n".join(lines)
+
+
+def format_result(result: dict, use_json: bool) -> str:
+    """Format result based on output preference."""
+    if use_json:
+        return json.dumps(result)
+    else:
+        return format_result_plain(result)
+
+
 def main():
     websites = []
     if cliArgs.input_file:
@@ -227,6 +286,8 @@ def main():
     else:
         websites.append(cliArgs.website)
     fetchPage = 1
+
+    use_json = cliArgs.json
 
     cnt = 0
     try:
@@ -284,15 +345,19 @@ def main():
                 if len(result["users"]) > 0:
                     found = True
             if not found:
-                logging.info(json.dumps({"message": "no results", "target": website}))
+                if use_json:
+                    logging.info(json.dumps({"message": "no results", "target": website}))
+                else:
+                    logging.info(f"No results for {website}")
             else:
+                output = format_result(result, use_json)
                 if cliArgs.output_file:
                     with open(cliArgs.output_file, "a") as f:
                         if cnt > 0:
                             f.write("\n")
-                        f.write(json.dumps(result))
+                        f.write(output)
                 else:
-                    print(json.dumps(result))
+                    print(output)
             cnt += 1
     except json.JSONDecodeError as e:
         logging.warning(f"JSON decode error {e=}, {type(e)=}")


### PR DESCRIPTION
## Summary

Changes the default output format from JSON to human-readable plain text. JSON output is now available via the `--json` flag.

## Changes

- Added `--json` / `-j` flag to enable JSON output
- Default output is now plain-text, formatted for easy reading
- Plain-text output includes clear section headers and organized formatting for all resource types (users, posts, pages, media, comments)
- Updated README with usage examples for both output formats

## Plain-text output example

```
===== targetwebsite.com =====

[Users]
  Name: John Doe
  Username: johndoe
  ---

[Media]
  https://targetwebsite.com/wp-content/uploads/2024/01/doc.pdf

[Posts]
  https://targetwebsite.com/?p=123

[Pages]
  https://targetwebsite.com/?page_id=2

[Comments]
  Name: Jane Doe
  Date: 2024-01-15T10:30:00
  Link: https://targetwebsite.com/hello-world/#comment-1
  ---
```

---
*River Security Automation*
*Trello: https://trello.com/c/8c1qnYGu/1-add-option-to-output-in-plain-text-not-just-json*