### PR TITLE
Add plain-text output as default, make JSON optional with --json flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,27 @@ A WordPress rest-enumeration script
 `pip install -r requirements.txt`
 
 # Usage
-Enumerate users and media files: `python ./wordpress-rest-enum.py -w https://targetwebsite.com -u -m `
+Enumerate users and media files (plain-text output): `python ./wordpress-rest-enum.py -w https://targetwebsite.com -u -m`
+
+Enumerate users and media files (JSON output): `python ./wordpress-rest-enum.py -w https://targetwebsite.com -u -m --json`
+
+## Output Formats
+
+### Plain Text (default)
+```
+========================================
+Website: https://targetwebsite.com
+========================================
+
+--- Users ---
+  John Doe (johndoe)
+  Jane Smith (janesmith)
+
+--- Media ---
+  https://targetwebsite.com/wp-content/uploads/doc.pdf
+```
+
+### JSON (`--json`)
+```json
+{"website": "https://targetwebsite.com", "users": [{"name": "John Doe", "username": "johndoe"}], "media": ["https://targetwebsite.com/wp-content/uploads/doc.pdf"]}
+```

--- a/wordpress-rest-enum.py
+++ b/wordpress-rest-enum.py
@@ -91,6 +91,14 @@ parser.add_argument(
     required=False,
 )
 
+parser.add_argument(
+    "--json",
+    help="Output results in JSON format (default is plain text)",
+    action="store_true",
+    default=False,
+    dest="json_output",
+)
+
 cliArgs = parser.parse_args()
 
 # Logging
@@ -216,6 +224,49 @@ def requestRESTAPI(
     return results
 
 
+def format_plain_text(result: dict) -> str:
+    """Format a result dictionary as human-readable plain text."""
+    lines = []
+    lines.append("")
+    lines.append("=" * 40)
+    lines.append(f"Website: {result['website']}")
+    lines.append("=" * 40)
+
+    if "users" in result and result["users"]:
+        lines.append("")
+        lines.append("--- Users ---")
+        for user in result["users"]:
+            lines.append(f"  {user['name']} ({user['username']})")
+
+    if "posts" in result and result["posts"]:
+        lines.append("")
+        lines.append("--- Posts ---")
+        for post in result["posts"]:
+            lines.append(f"  {post}")
+
+    if "pages" in result and result["pages"]:
+        lines.append("")
+        lines.append("--- Pages ---")
+        for page in result["pages"]:
+            lines.append(f"  {page}")
+
+    if "comments" in result and result["comments"]:
+        lines.append("")
+        lines.append("--- Comments ---")
+        for comment in result["comments"]:
+            lines.append(f"  {comment['name']} ({comment['date']})")
+            lines.append(f"    {comment['link']}")
+
+    if "media" in result and result["media"]:
+        lines.append("")
+        lines.append("--- Media ---")
+        for media in result["media"]:
+            lines.append(f"  {media}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
 def main():
     websites = []
     if cliArgs.input_file:
@@ -284,15 +335,23 @@ def main():
                 if len(result["users"]) > 0:
                     found = True
             if not found:
-                logging.info(json.dumps({"message": "no results", "target": website}))
+                if cliArgs.json_output:
+                    logging.info(json.dumps({"message": "no results", "target": website}))
+                else:
+                    logging.info(f"No results for {website}")
             else:
+                if cliArgs.json_output:
+                    output = json.dumps(result)
+                else:
+                    output = format_plain_text(result)
+
                 if cliArgs.output_file:
                     with open(cliArgs.output_file, "a") as f:
                         if cnt > 0:
                             f.write("\n")
-                        f.write(json.dumps(result))
+                        f.write(output)
                 else:
-                    print(json.dumps(result))
+                    print(output)
             cnt += 1
     except json.JSONDecodeError as e:
         logging.warning(f"JSON decode error {e=}, {type(e)=}")


### PR DESCRIPTION
## Summary

Changes the default output format from JSON to human-readable plain text, and adds a `--json` flag to opt into JSON output.

## Changes

- **Added `--json` flag**: Users can pass `--json` to get the previous JSON output behavior.
- **Plain-text output (new default)**: Results are now displayed in a readable plain-text format by default:
  - Website header with separator line
  - Users shown as `name (username)`
  - Posts, pages, and media shown as URL lists
  - Comments shown with name, date, and link
- **Output file support**: Both plain-text and JSON formats work with the `-o`/`--output-file` option.
- **Updated README**: Documents the new `--json` flag and shows example output.

## Examples

### Plain text (default)
```
$ python wordpress-rest-enum.py -w https://example.com -u -m

========================================
Website: https://example.com
========================================

--- Users ---
John Doe (johndoe)
Jane Smith (janesmith)

--- Media ---
https://example.com/wp-content/uploads/doc.pdf
https://example.com/wp-content/uploads/report.csv
```

### JSON output
```
$ python wordpress-rest-enum.py -w https://example.com -u -m --json
{"website": "https://example.com", "users": [...], "media": [...]}
```

---
*River Security Automation*
*Trello: https://trello.com/c/8c1qnYGu/1-add-option-to-output-in-plain-text-not-just-json*