### PR TITLE
Add plain-text output as default, JSON via --json flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ A WordPress rest-enumeration script
 
 # Usage
 Enumerate users and media files: `python ./wordpress-rest-enum.py -w https://targetwebsite.com -u -m `
+
+Output in JSON format: `python ./wordpress-rest-enum.py -w https://targetwebsite.com -u -m --json`


### PR DESCRIPTION
- Plain-text output is now the default format
- Added `--json` flag to output in JSON format
- Added `format_plain_text()` function for human-readable output
- Updated README with `--json` usage example

---
*River Security Automation*
*Trello: https://trello.com/c/8c1qnYGu/1-add-option-to-output-in-plain-text-not-just-json*