### PR TITLE
Use browser-like headers to avoid WAF 403s

### DIFF
--- a/wordpress-rest-enum.py
+++ b/wordpress-rest-enum.py
@@ -104,7 +104,19 @@ cliArgs = parser.parse_args()
 logging.basicConfig(level=cliArgs.log_level)
 
 # Globals
-HEADERS = {"User-Agent": "WordPress Testing"}
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+    "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
+    "sec-ch-ua": '"Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Upgrade-Insecure-Requests": "1",
+}
 # Create a single session for reuse
 SESSION = requests.Session()
 SESSION.headers.update(HEADERS)


### PR DESCRIPTION
## Summary
- Some WAFs returned 403 for every REST endpoint because the script's `User-Agent: WordPress Testing` was an obvious scanner signature. Swapping in a bare Chrome UA wasn't enough either — the WAF fingerprints the full header shape.
- Updated `HEADERS` to a realistic Chrome-on-Windows set (UA + `Accept`, `Accept-Language`, `sec-ch-ua*`, `Sec-Fetch-*`, `Upgrade-Insecure-Requests`), which gets a 200 from the same endpoints with no cookies needed.

## Test plan
- [x] `curl` with only browser-like headers (no cookies) against a WAF-protected WP REST endpoint → 200
- [ ] Re-run the script against the same target with `--log-level DEBUG` and confirm results return instead of 403s
- [ ] Sanity-check against an unprotected WordPress site to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)